### PR TITLE
Corrected bucket.replace paramaters

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,7 +297,7 @@ app.post('/api/user/:username/flights', authUser, function(req, res) {
 
     doc.value.flights  = doc.value.flights.concat(flights);
 
-    bucket.replace(userDocKey, {cas: doc.cas}, doc.value, function(err, res) {
+    bucket.replace(userDocKey, doc.value, {cas: doc.cas}, function(err, success) {
       if (err) {
         res.status(500).send({
           error: err


### PR DESCRIPTION
Posting a flight form the cart was giving rise to 2 errors on my machine which I traced to the bucket.replace code.

1. The function callback  `function(err, res) { ...` was redefining the _res_ variable from the enclosing post function instead of creating a new variable for success.  If an error occurs then the _res_ variable is set to null and the call to `res.status(500).send` fails, and in my case aborts the program.
2. The order of the parameters is incorrect.  According to the SDK documentation bucket .replace is **replace(key, value, options, callback)** but the code is using **replace(key, options, value, callback)**  This error was causing the post flight to fail.

The attached commit has the corrected bucket.replace parameters.